### PR TITLE
Mention Maven artifact coordinates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 Additional validator implementations for [javax.validation](http://beanvalidation.org/).
-Most validators use [Apache Commons Lang3](http://commons.apache.org/lang/) and 
+Most validators use [Apache Commons Lang3](http://commons.apache.org/lang/) and
 [Apache Commons Validator](http://commons.apache.org/validator/) functionality to implement various validation routines.
 
 More information can be found on the [project website](https://britter.github.io/bean-validators).
+
+## Usage
+
+Add the following to your Maven dependency list:
+
+```
+<dependency>
+  <groupId>com.github.britter</groupId>
+  <artifactId>bean-validators</artifactId>
+  <version>0.6.1</version>
+</dependency>
+```
 
 ## How to release
 
@@ -27,4 +39,3 @@ Code is under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.
 + [javax.validation reference implementation](http://hibernate.org/validator/)
 + [Apache Commons Lang3](http://commons.apache.org/lang/)
 + [Apache Commons Validator](http://commons.apache.org/validator/)
-


### PR DESCRIPTION
As a user one of the first objectives is to include a project in a
dependency management system. It would be easier if the README would
mention the project coordinates and the obligatory Maven XML snippet.