### PR TITLE
Update commons-validator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.4.1</version>
+      <version>1.5.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Update to the latest version 1.5.0 of commons-validator.