### PR TITLE
fix validation for null and blank values in @AlphaNumeric & @Alphabetic

### DIFF
--- a/src/main/java/com/github/britter/beanvalidators/strings/AlphaNumericConstraintValidator.java
+++ b/src/main/java/com/github/britter/beanvalidators/strings/AlphaNumericConstraintValidator.java
@@ -32,7 +32,7 @@ public class AlphaNumericConstraintValidator implements ConstraintValidator<Alph
     @Override
     public boolean isValid(final String value, final ConstraintValidatorContext context) {
         // Don't validate null, empty and blank strings, since these are validated by @NotNull, @NotEmpty and @NotBlank
-        return StringUtils.isBlank(value) || allowSpaces ? StringUtils.isAlphanumericSpace(value) : StringUtils.isAlphanumeric(value);
+        return StringUtils.isBlank(value) || (allowSpaces ? StringUtils.isAlphanumericSpace(value) : StringUtils.isAlphanumeric(value));
     }
 
 }

--- a/src/main/java/com/github/britter/beanvalidators/strings/AlphabeticConstraintValidator.java
+++ b/src/main/java/com/github/britter/beanvalidators/strings/AlphabeticConstraintValidator.java
@@ -32,7 +32,7 @@ public class AlphabeticConstraintValidator implements ConstraintValidator<Alphab
     @Override
     public boolean isValid(final String value, final ConstraintValidatorContext context) {
         // Don't validate null, empty and blank strings, since these are validated by @NotNull, @NotEmpty and @NotBlank
-        return StringUtils.isBlank(value) || allowSpaces ? StringUtils.isAlphaSpace(value) : StringUtils.isAlpha(value);
+        return StringUtils.isBlank(value) || (allowSpaces ? StringUtils.isAlphaSpace(value) : StringUtils.isAlpha(value));
     }
 
 }

--- a/src/test/java/com/github/britter/beanvalidators/strings/AlphaNumericTest.java
+++ b/src/test/java/com/github/britter/beanvalidators/strings/AlphaNumericTest.java
@@ -54,6 +54,21 @@ public class AlphaNumericTest {
     }
 
     @Test
+    public void defaultSettingsShouldValidateNull() throws Exception {
+        alphaNumBean.alphaNum = null;
+
+        validator.assertNoViolations("alphaNum");
+    }
+
+    @Test
+    public void defaultSettingsShouldValidateBlankString() throws Exception {
+        alphaNumBean.alphaNum = "";
+
+        validator.assertNoViolations("alphaNum");
+    }
+
+
+    @Test
     public void defaultSettingsShouldNotValidateNonAlphabeticString() throws Exception {
         alphaNumBean.alphaNum = "abcd?";
 
@@ -81,6 +96,7 @@ public class AlphaNumericTest {
 
         assertThat(violations, hasSize(1));
     }
+
 
     @Test
     public void allowSpacesSettingsShouldValidateAlphabeticString() throws Exception {

--- a/src/test/java/com/github/britter/beanvalidators/strings/AlphabeticTest.java
+++ b/src/test/java/com/github/britter/beanvalidators/strings/AlphabeticTest.java
@@ -47,6 +47,20 @@ public class AlphabeticTest {
     }
 
     @Test
+    public void defaultSettingsShouldValidateNull() throws Exception {
+        alphabeticBean.alphabetic = null;
+
+        validator.assertNoViolations("alphabetic");
+    }
+
+    @Test
+    public void defaultSettingsShouldValidateBlankString() throws Exception {
+        alphabeticBean.alphabetic = "";
+
+        validator.assertNoViolations("alphabetic");
+    }
+
+    @Test
     public void defaultSettingsShouldNotValidateNonAlphabeticString() throws Exception {
         alphabeticBean.alphabetic = "abcd123";
 


### PR DESCRIPTION
I guess AlphaNumeric and Alphabetic validations did not behave as intended. From the code comments null or blank values should be valid, right?