### PR TITLE
Add dependency to javax.xml.bind:jaxb-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ sudo: false
 
 jdk:
   - openjdk8
+  - openjdk11
 
 after_success:
   - ./gradlew jacocoTestReport coveralls

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,4 +39,5 @@ dependencies {
     testFixturesApi("org.assertj:assertj-core:3.8.0")
     testFixturesApi("javax.el:javax.el-api:3.0.0")
     testFixturesImplementation("com.google.guava:guava:23.0")
+    testFixturesImplementation("javax.xml.bind:jaxb-api:2.3.1")
 }


### PR DESCRIPTION
This was part of the JDK until Java 10. In Java 9 it got deprecated and
in Java 11 it was removed.

See https://openjdk.java.net/jeps/320#Java-EE-modules