### PR TITLE
Refine condition for running only on Linux

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -35,7 +35,7 @@ jobs:
     - run: ./gradlew check
       id: gradle
     - name: Coveralls
-      if: ${{ matrix.os }} == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: ./gradlew jacocoTestReport coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
It did not seem to work with the ${{ }}. A stackoverflow article
suggested removing that.
